### PR TITLE
Fix reference to node-version parameter when passing to setup-node

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v3.8.1
       with:
-        node-version: ${{inputs.node_version}}
+        node-version: ${{inputs.node-version}}
     - name: Cache ~/.cache
       id: cache
       uses: actions/cache@v3


### PR DESCRIPTION
# Description

Fix reference to node-version parameter when passing to setup-node

## Type of change

<!-- Please check all items that apply (as [x]). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation only

# Checklist:

<!-- Please check all items that apply (as [x]). -->

- [x] My code follows the style and commit guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
